### PR TITLE
Remove tddworkshop.com domain references

### DIFF
--- a/cms/content/blog/react-compound-components.mdx
+++ b/cms/content/blog/react-compound-components.mdx
@@ -178,14 +178,14 @@ export { Nav };
   ReactJS Conf_ in 2017), and it is called **_Compound components_**.
 - [Radix UI][radix] uses this pattern extensively.
 - If you’re curious, I used this pattern to build the whole landing page for my
-  tddworkshop.com page. You can check the source code [here][tddworkshop].
+  [tddworkshop.com project][tddworkshop].
 
 Happy hacking!
 
 [vue-slots]: https://vuejs.org/guide/components/slots.html#named-slots
 [open-closed]: https://en.wikipedia.org/wiki/Open%E2%80%93closed_principle
 [tddworkshop]:
-  https://github.com/codecoolture/tddworkshop.com/blob/trunk/pages/en/index.tsx
+  https://github.com/codecoolture/tddworkshop.com
 [radix]: https://www.radix-ui.com/
 [kentcdodds]: https://kentcdodds.com/
 [soul-crushing-components]: https://epicreact.dev/soul-crushing-components/

--- a/pages/about.mdx
+++ b/pages/about.mdx
@@ -23,9 +23,8 @@ export default ({ children }) => {
 My main interests are software design, product development (I have not only
 worked at product companies but also on multiple side projects), and team
 leadership. I have experience coaching and mentoring software teams. I’m a
-strong advocate of practices such as test-driven development (hey, [I even have
-a workshop about it][tddworkshop]!), continuous delivery, and (true) Agile
-approaches.
+strong advocate of practices such as test-driven development, continuous
+delivery, and (true) Agile approaches.
 
 In 2016 I co-founded [AsturiasHacking][asturiashacking], the first large
 software group in Asturias, Spain.
@@ -43,4 +42,3 @@ If you want to know more about me, please check out my [Bluesky feed][bsky],
 [bsky]: https://bsky.app/profile/sergio.codecoolture.com
 [github]: https://github.com/codecoolture
 [linkedin]: https://linkedin.com/in/sergioalvarezsuarez
-[tddworkshop]: https://tddworkshop.com


### PR DESCRIPTION
The tddworkshop.com domain is no longer being renewed since the workshop is no longer active. This removes references to the domain to avoid dead links.

- Removed the inline mention and link from the about page, keeping the TDD advocacy text intact.
- Updated the blog post link to point to the GitHub repository instead of a specific file path tied to the old domain.